### PR TITLE
Install datapackage from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-slugify==1.1.4
--e git://github.com/okfn/datapackage-py.git@master#egg=datapackage
+datapackage==0.6.1


### PR DESCRIPTION
Fixes #45

As a first step this removes the github dependency and just specifies the (currently) latest datapackage version to be installed from PyPi.

Once this is merged we should be able to also move that dependency into the `setup.py` and publish this package on PyPi as well.