### PR TITLE
Replace httpretty with requests_mock

### DIFF
--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+# solr is multicore for tests on ckan master now, but it's easier to run tests
+# on Travis single-core still.
+# see https://github.com/ckan/ckan/issues/2972
+sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
 echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart

--- a/ckanext/datapackager/tests/controllers/test_datapackage.py
+++ b/ckanext/datapackager/tests/controllers/test_datapackage.py
@@ -2,7 +2,7 @@
 import json
 
 import nose.tools
-import httpretty
+import requests_mock
 import ckanapi
 import datapackage
 
@@ -20,7 +20,6 @@ class TestDataPackageController(
         custom_helpers.FunctionalTestBaseClass):
     '''Functional tests for the DataPackageController class.'''
 
-    @httpretty.activate
     def test_download_datapackage(self):
         '''Test downloading a DataPackage file of a package.
 
@@ -97,9 +96,8 @@ class TestDataPackageController(
         response = self.app.get(url, extra_environ=env, status=[401])
         assert_true('Unauthorized to create a dataset' in response.body)
 
-    @httpretty.activate
-    def test_import_datapackage(self):
-        httpretty.HTTPretty.allow_net_connect = False
+    @requests_mock.Mocker(real_http=True)
+    def test_import_datapackage(self, mock_requests):
         datapackage_url = 'http://www.foo.com/datapackage.json'
         datapackage = {
             'name': 'foo',
@@ -110,8 +108,7 @@ class TestDataPackageController(
                 }
             ]
         }
-        httpretty.register_uri(httpretty.GET, datapackage_url,
-                               body=json.dumps(datapackage))
+        mock_requests.register_uri('GET', datapackage_url, json=datapackage)
 
         user = factories.User()
         env = {'REMOTE_USER': user['name'].encode('ascii')}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,4 @@
 nose==1.3.7
 ckanapi==3.5
 beautifulsoup4==4.4.1
-httpretty==0.8.3
+requests-mock==1.0.0


### PR DESCRIPTION
Fixes #32 

As addressed in #32 there were some problems with httpretty blocking all requests that were made by the application under test. This PR changes the mocking library to [requests_mock](https://pypi.python.org/pypi/requests-mock) which works as desired.

As a result all tests are passing again 🎉 