### PR TITLE
Fix #84: Get uploaded datapackage file from request

### DIFF
--- a/ckanext/datapackager/controllers/datapackage.py
+++ b/ckanext/datapackager/controllers/datapackage.py
@@ -50,8 +50,9 @@ def import_datapackage():
         else:
             params = toolkit.request.params
 
-        if 'files' in toolkit.request and 'upload' in toolkit.request.files:
-            params['upload'] = toolkit.request.files['upload']
+        if toolkit.check_ckan_version(min_version="2.9"):
+            if 'upload' in toolkit.request.files:
+                params['upload'] = toolkit.request.files['upload']
 
         dataset = toolkit.get_action('package_create_from_datapackage')(
             context,

--- a/ckanext/datapackager/controllers/datapackage.py
+++ b/ckanext/datapackager/controllers/datapackage.py
@@ -50,7 +50,7 @@ def import_datapackage():
         else:
             params = toolkit.request.params
 
-        if 'upload' in toolkit.request.files:
+        if 'files' in toolkit.request and 'upload' in toolkit.request.files:
             params['upload'] = toolkit.request.files['upload']
 
         dataset = toolkit.get_action('package_create_from_datapackage')(

--- a/ckanext/datapackager/controllers/datapackage.py
+++ b/ckanext/datapackager/controllers/datapackage.py
@@ -46,9 +46,12 @@ def import_datapackage():
 
     try:
         if hasattr(toolkit.request, "form") and len(list(toolkit.request.form.keys())) > 0:
-            params = toolkit.request.form
+            params = toolkit.request.form.to_dict()
         else:
             params = toolkit.request.params
+
+        if 'upload' in toolkit.request.files:
+            params['upload'] = toolkit.request.files['upload']
 
         dataset = toolkit.get_action('package_create_from_datapackage')(
             context,

--- a/ckanext/datapackager/logic/action/create.py
+++ b/ckanext/datapackager/logic/action/create.py
@@ -88,7 +88,7 @@ def _load_and_validate_datapackage(url=None, upload=None):
     try:
 
         if _upload_attribute_is_valid(upload):
-            dp = datapackage.DataPackage(upload.file)
+            dp = datapackage.DataPackage(upload)
         else:
 
             dp = datapackage.DataPackage(url)
@@ -186,7 +186,7 @@ def _create_and_upload_resource(context, resource, the_file):
 
 
 def _upload_attribute_is_valid(upload):
-    return hasattr(upload, 'file') and hasattr(upload.file, 'read')
+    return hasattr(upload, 'read')
 
 
 class _UploadLocalFileStorage(FileStorage):

--- a/ckanext/datapackager/logic/action/create.py
+++ b/ckanext/datapackager/logic/action/create.py
@@ -88,7 +88,10 @@ def _load_and_validate_datapackage(url=None, upload=None):
     try:
 
         if _upload_attribute_is_valid(upload):
-            dp = datapackage.DataPackage(upload)
+            if toolkit.check_ckan_version(min_version="2.9"):
+                dp = datapackage.DataPackage(upload)
+            else:
+                dp = datapackage.DataPackage(upload.file)
         else:
 
             dp = datapackage.DataPackage(url)
@@ -186,7 +189,7 @@ def _create_and_upload_resource(context, resource, the_file):
 
 
 def _upload_attribute_is_valid(upload):
-    return hasattr(upload, 'read')
+    return hasattr(upload, 'read') or hasattr(upload, 'file') and hasattr(upload.file, 'read')
 
 
 class _UploadLocalFileStorage(FileStorage):

--- a/ckanext/datapackager/logic/action/create.py
+++ b/ckanext/datapackager/logic/action/create.py
@@ -183,7 +183,11 @@ def _create_and_upload_local_resource(context, resource):
 def _create_and_upload_resource(context, resource, the_file):
     resource['url'] = 'url'
     resource['url_type'] = 'upload'
-    resource['upload'] = FileStorage(the_file, the_file.name, the_file.name)
+
+    if toolkit.check_ckan_version(min_version="2.9"):
+        resource['upload'] = FileStorage(the_file, the_file.name, the_file.name)
+    else:
+        resource['upload'] = _UploadLocalFileStorage(the_file)
 
     toolkit.get_action('resource_create')(context, resource)
 
@@ -191,8 +195,8 @@ def _create_and_upload_resource(context, resource, the_file):
 def _upload_attribute_is_valid(upload):
     return hasattr(upload, 'read') or hasattr(upload, 'file') and hasattr(upload.file, 'read')
 
-
-class _UploadLocalFileStorage(FileStorage):
+# Used only in CKAN < 2.9
+class _UploadLocalFileStorage(cgi.FileStorage):
     def __init__(self, fp, *args, **kwargs):
         self.name = fp.name
         self.filename = fp.name

--- a/ckanext/datapackager/logic/action/create.py
+++ b/ckanext/datapackager/logic/action/create.py
@@ -196,7 +196,7 @@ def _upload_attribute_is_valid(upload):
     return hasattr(upload, 'read') or hasattr(upload, 'file') and hasattr(upload.file, 'read')
 
 # Used only in CKAN < 2.9
-class _UploadLocalFileStorage(cgi.FileStorage):
+class _UploadLocalFileStorage(cgi.FieldStorage):
     def __init__(self, fp, *args, **kwargs):
         self.name = fp.name
         self.filename = fp.name

--- a/ckanext/datapackager/tests/logic/action/test_create.py
+++ b/ckanext/datapackager/tests/logic/action/test_create.py
@@ -1,6 +1,6 @@
 import json
 import tempfile
-from six import StringIO
+from six import StringIO, BytesIO
 import six
 try:
     from unittest import mock
@@ -48,8 +48,7 @@ class TestPackageCreateFromDataPackage():
             ]
         }
 
-        upload = mock.MagicMock()
-        upload.file = StringIO(json.dumps(datapackage))
+        upload = StringIO(json.dumps(datapackage))
 
 
         with pytest.raises(toolkit.ValidationError):
@@ -299,7 +298,7 @@ class TestPackageCreateFromDataPackage():
             tmpfile.flush()
 
             dataset = helpers.call_action('package_create_from_datapackage',
-                                          upload=_UploadFile(tmpfile))
+                                          upload=tmpfile)
             assert dataset['name'] == 'foo'
 
 

--- a/ckanext/datapackager/tests/logic/action/test_create.py
+++ b/ckanext/datapackager/tests/logic/action/test_create.py
@@ -48,8 +48,11 @@ class TestPackageCreateFromDataPackage():
             ]
         }
 
-        upload = StringIO(json.dumps(datapackage))
-
+        if toolkit.check_ckan_version(min_version="2.9"):
+            upload = StringIO(json.dumps(datapackage))
+        else:
+            upload = mock.MagicMock()
+            upload.file = StringIO(json.dumps(datapackage))
 
         with pytest.raises(toolkit.ValidationError):
             helpers.call_action('package_create_from_datapackage', upload=upload)


### PR DESCRIPTION
Fix #84, getting the uploaded file data from toolkit.request.files